### PR TITLE
KCL shardend fix for V1

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
@@ -1,5 +1,9 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
+
 /**
  * An implementation of ShardSyncStrategy.
  */
@@ -33,6 +37,11 @@ class PeriodicShardSyncStrategy implements ShardSyncStrategy {
 
     @Override
     public TaskResult onShardConsumerShutDown() {
+        return new TaskResult(null);
+    }
+
+    @Override
+    public TaskResult onShardConsumerShutDown(List<Shard> shards) {
         return new TaskResult(null);
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -1,8 +1,10 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -53,6 +55,11 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
     @Override
     public TaskResult onShardConsumerShutDown() {
         return onFoundCompletedShard();
+    }
+
+    public TaskResult onShardConsumerShutDown(List<Shard> shards) {
+        shardSyncTaskManager.syncShardAndLeaseInfo(shards);
+        return new TaskResult(null);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -1,5 +1,9 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
+
 /**
  * Facade of methods that can be invoked at different points
  * in KCL application execution to perform certain actions related to shard-sync.
@@ -40,6 +44,13 @@ public interface ShardSyncStrategy {
      * @return
      */
     TaskResult onShardConsumerShutDown();
+
+    /**
+     * Invoked when ShardConsumer is shutdown and all shards are provided.
+     *
+     * @return
+     */
+    TaskResult onShardConsumerShutDown(List<Shard> shards);
 
     /**
      * Invoked when worker is shutdown.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -14,12 +14,15 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+
+import java.util.List;
 
 /**
  * This task syncs leases/activies with shards of the stream.
@@ -39,6 +42,7 @@ class ShardSyncTask implements ITask {
     private final long shardSyncTaskIdleTimeMillis;
     private final TaskType taskType = TaskType.SHARDSYNC;
     private final ShardSyncer shardSyncer;
+    private final List<Shard> shards;
 
     /**
      * @param kinesisProxy Used to fetch information about the stream (e.g. shard list)
@@ -51,13 +55,14 @@ class ShardSyncTask implements ITask {
      * @param shardSyncTaskIdleTimeMillis shardSync task idle time in millis
      * @param shardSyncer shardSyncer instance used to check and create new leases
      */
-    ShardSyncTask(IKinesisProxy kinesisProxy,
+    ShardSyncTask(List<Shard> shards, IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager,
             InitialPositionInStreamExtended initialPositionInStream,
             boolean cleanupLeasesUponShardCompletion,
             boolean ignoreUnexpectedChildShards,
             long shardSyncTaskIdleTimeMillis,
             ShardSyncer shardSyncer) {
+        this.shards = shards;
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;
         this.initialPosition = initialPositionInStream;
@@ -75,7 +80,7 @@ class ShardSyncTask implements ITask {
         Exception exception = null;
 
         try {
-            shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy,
+            shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy,
                     leaseManager,
                     initialPosition,
                     cleanupLeasesUponShardCompletion,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -14,11 +14,13 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import lombok.Getter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -85,11 +87,11 @@ class ShardSyncTaskManager {
         this.shardSyncer = shardSyncer;
     }
 
-    synchronized Future<TaskResult> syncShardAndLeaseInfo(Set<String> closedShardIds) {
-        return checkAndSubmitNextTask(closedShardIds);
+    synchronized Future<TaskResult> syncShardAndLeaseInfo(List<Shard> shards) {
+        return checkAndSubmitNextTask(shards);
     }
 
-    private synchronized Future<TaskResult> checkAndSubmitNextTask(Set<String> closedShardIds) {
+    private synchronized Future<TaskResult> checkAndSubmitNextTask(List<Shard> shards) {
         Future<TaskResult> submittedTaskFuture = null;
         if ((future == null) || future.isCancelled() || future.isDone()) {
             if ((future != null) && future.isDone()) {
@@ -105,7 +107,7 @@ class ShardSyncTaskManager {
             }
 
             currentTask =
-                    new MetricsCollectingTaskDecorator(new ShardSyncTask(kinesisProxy,
+                    new MetricsCollectingTaskDecorator(new ShardSyncTask(shards, kinesisProxy,
                             leaseManager,
                             initialPositionInStream,
                             cleanupLeasesUponShardCompletion,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
@@ -21,12 +21,15 @@ import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;
 import com.amazonaws.services.kinesis.leases.exceptions.ProvisionedThroughputException;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
 
 public interface ShardSyncer {
 
-    void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
-            InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
-            boolean ignoreUnexpectedChildShards)
+    void checkAndCreateLeasesForNewShards(List<Shard> shards, IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
+                                          InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
+                                          boolean ignoreUnexpectedChildShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException;
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -677,7 +677,7 @@ public class Worker implements Runnable {
                 if (!skipShardSyncAtWorkerInitializationIfLeasesExist
                         || leaseCoordinator.getLeaseManager().isLeaseTableEmpty()) {
                     LOG.info("Syncing Kinesis shard info");
-                    ShardSyncTask shardSyncTask = new ShardSyncTask(streamConfig.getStreamProxy(),
+                    ShardSyncTask shardSyncTask = new ShardSyncTask(null, streamConfig.getStreamProxy(),
                             leaseCoordinator.getLeaseManager(), initialPosition, cleanupLeasesUponShardCompletion,
                             config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer);
                     result = new MetricsCollectingTaskDecorator(shardSyncTask, metricsFactory).call();
@@ -1164,7 +1164,7 @@ public class Worker implements Runnable {
             ILeaseManager<KinesisClientLease> leaseManager) {
         return new PeriodicShardSyncStrategy(
                 new PeriodicShardSyncManager(config.getWorkerIdentifier(), leaderDecider,
-                        new ShardSyncTask(kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
+                        new ShardSyncTask(null, kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
                                 config.shouldCleanupLeasesUponShardCompletion(),
                                 config.shouldIgnoreUnexpectedChildShards(), SHARD_SYNC_SLEEP_FOR_PERIODIC_SHARD_SYNC,
                                 shardSyncer), metricsFactory));

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
@@ -121,7 +121,7 @@ public class ShardSyncTaskIntegrationTest {
         }
         leaseManager.deleteAll();
         Set<String> shardIds = kinesisProxy.getAllShardIds();
-        ShardSyncTask syncTask = new ShardSyncTask(kinesisProxy,
+        ShardSyncTask syncTask = new ShardSyncTask(null, kinesisProxy,
                 leaseManager,
                 InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST),
                 false,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -16,14 +16,19 @@ package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
-import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+import com.amazonaws.services.kinesis.model.HashKeyRange;
+import com.amazonaws.services.kinesis.model.SequenceNumberRange;
+import com.amazonaws.services.kinesis.model.Shard;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -53,7 +58,7 @@ public class ShutdownTaskTest {
 
     Set<String> defaultParentShardIds = new HashSet<>();
     String defaultConcurrencyToken = "testToken4398";
-    String defaultShardId = "shardId-0000397840";
+    String defaultShardId = "shardId-0";
     ShardInfo defaultShardInfo = new ShardInfo(defaultShardId,
             defaultConcurrencyToken,
             defaultParentShardIds,
@@ -104,6 +109,8 @@ public class ShutdownTaskTest {
         RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
         when(checkpointer.getLastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        List<Shard> shards = constructShardListForGraphA();
+        when(kinesisProxy.getShardList()).thenReturn(shards);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
@@ -132,12 +139,14 @@ public class ShutdownTaskTest {
     public final void testCallWhenSyncingShardsThrows() {
         RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
         when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
-        when(kinesisProxy.getShardList()).thenReturn(null);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
-        when(shardSyncStrategy.onShardConsumerShutDown()).thenReturn(new TaskResult(new KinesisClientLibIOException("")));
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(new KinesisClientLibIOException("")));
         ShutdownTask task = new ShutdownTask(defaultShardInfo,
                 defaultRecordProcessor,
                 checkpointer,
@@ -152,9 +161,109 @@ public class ShutdownTaskTest {
                 shardSyncer,
                 shardSyncStrategy);
         TaskResult result = task.call();
-        verify(shardSyncStrategy).onShardConsumerShutDown();
+        verify(shardSyncStrategy).onShardConsumerShutDown(shards);
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof KinesisClientLibIOException);
+        verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenShardEnd() {
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.TERMINATE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseManager,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, times(1)).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenFalseShardEnd() {
+        ShardInfo shardInfo = new ShardInfo("shardId-4",
+                                                   defaultConcurrencyToken,
+                                                   defaultParentShardIds,
+                                                   ExtendedSequenceNumber.LATEST);
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(shardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.TERMINATE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseManager,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy, never()).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, times(1)).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenLeaseLost() {
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.ZOMBIE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseManager,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy, never()).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, never()).getShardList();
+        Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
     }
 
@@ -165,6 +274,54 @@ public class ShutdownTaskTest {
     public final void testGetTaskType() {
         ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer, shardSyncStrategy);
         Assert.assertEquals(TaskType.SHUTDOWN, task.getTaskType());
+    }
+
+
+    /*
+     * Helper method to construct a shard list for graph A. Graph A is defined below.
+     * Shard structure (y-axis is epochs):
+     * 0 1 2 3 4   5- shards till epoch 102
+     * \ / \ / |  |
+     *  6   7  4   5- shards from epoch 103 - 205
+     *   \ /   |  /\
+     *    8    4 9 10 - shards from epoch 206 (open - no ending sequenceNumber)
+     */
+    private List<Shard> constructShardListForGraphA() {
+        List<Shard> shards = new ArrayList<Shard>();
+
+        SequenceNumberRange range0 = ShardObjectHelper.newSequenceNumberRange("11", "102");
+        SequenceNumberRange range1 = ShardObjectHelper.newSequenceNumberRange("11", null);
+        SequenceNumberRange range2 = ShardObjectHelper.newSequenceNumberRange("11", "210");
+        SequenceNumberRange range3 = ShardObjectHelper.newSequenceNumberRange("103", "210");
+        SequenceNumberRange range4 = ShardObjectHelper.newSequenceNumberRange("211", null);
+
+        HashKeyRange hashRange0 = ShardObjectHelper.newHashKeyRange("0", "99");
+        HashKeyRange hashRange1 = ShardObjectHelper.newHashKeyRange("100", "199");
+        HashKeyRange hashRange2 = ShardObjectHelper.newHashKeyRange("200", "299");
+        HashKeyRange hashRange3 = ShardObjectHelper.newHashKeyRange("300", "399");
+        HashKeyRange hashRange4 = ShardObjectHelper.newHashKeyRange("400", "499");
+        HashKeyRange hashRange5 = ShardObjectHelper.newHashKeyRange("500", ShardObjectHelper.MAX_HASH_KEY);
+        HashKeyRange hashRange6 = ShardObjectHelper.newHashKeyRange("0", "199");
+        HashKeyRange hashRange7 = ShardObjectHelper.newHashKeyRange("200", "399");
+        HashKeyRange hashRange8 = ShardObjectHelper.newHashKeyRange("0", "399");
+        HashKeyRange hashRange9 = ShardObjectHelper.newHashKeyRange("500", "799");
+        HashKeyRange hashRange10 = ShardObjectHelper.newHashKeyRange("800", ShardObjectHelper.MAX_HASH_KEY);
+
+        shards.add(ShardObjectHelper.newShard("shardId-0", null, null, range0, hashRange0));
+        shards.add(ShardObjectHelper.newShard("shardId-1", null, null, range0, hashRange1));
+        shards.add(ShardObjectHelper.newShard("shardId-2", null, null, range0, hashRange2));
+        shards.add(ShardObjectHelper.newShard("shardId-3", null, null, range0, hashRange3));
+        shards.add(ShardObjectHelper.newShard("shardId-4", null, null, range1, hashRange4));
+        shards.add(ShardObjectHelper.newShard("shardId-5", null, null, range2, hashRange5));
+
+        shards.add(ShardObjectHelper.newShard("shardId-6", "shardId-0", "shardId-1", range3, hashRange6));
+        shards.add(ShardObjectHelper.newShard("shardId-7", "shardId-2", "shardId-3", range3, hashRange7));
+
+        shards.add(ShardObjectHelper.newShard("shardId-8", "shardId-6", "shardId-7", range4, hashRange8));
+        shards.add(ShardObjectHelper.newShard("shardId-9", "shardId-5", null, range4, hashRange9));
+        shards.add(ShardObjectHelper.newShard("shardId-10", null, "shardId-5", range4, hashRange10));
+
+        return shards;
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Re-validate if a shard_end is reached before shutting down the ShardConsumer with Shard_End reason.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
